### PR TITLE
User permissions management in the terminal

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -21,9 +21,6 @@ const EXITCODE_CPULOADFAILS: i32 = 2;
 
 static mut PERMISSIONS_HSHMP: Option<HashMap<String, bool>> = None;
 
-const READBYTE_IDX: usize = 0;
-const WRITEBYTE_IDX: usize = 1;
-
 #[derive(Default)]
 struct RenderOptions {
     pub linear_interpolation: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use rboy::device::{Device, FRAME_DURATION};
 use rboy::CPU_FREQUENCY;
 use std::cell::RefCell;
 use std::fs::File;
-use std::io::{self, Read};
+use std::io::{self, Read, Write};
 use std::rc::Rc;
 use std::sync::mpsc::{self, Receiver, SyncSender, TryRecvError, TrySendError};
 use std::sync::{Arc, Mutex};
@@ -471,7 +471,28 @@ fn construct_cpu(
     Some(c)
 }
 
+fn ask_user_for_permission(permission_name: &str) -> bool {
+    print!("Autorize {} ? (y/n, défaut: n): ", permission_name);
+    io::stdout().flush().unwrap();
+
+    let mut input = String::new();
+    io::stdin().read_line(&mut input).unwrap();
+
+    matches!(input.trim().to_lowercase().as_str(), "y")
+}
+
 fn load_permissions(lua: &mut Lua, perms: &PluginPermissions, cpu: &Rc<RefCell<Device>>) {
+
+    let perms_str = format!("{:?}", perms);
+
+    let trimmed_str = perms_str.trim_start_matches("PluginPermissions { ").trim_end_matches(" }");
+
+    for line in trimmed_str.split(", ") {
+        let (name, value) = line.split_once(": ").unwrap();
+        ask_user_for_permission(name.trim());
+        // println!("[DEBUG] {}: {}", name.trim(), value.trim());
+    }
+
     if perms.readbyte {
         let rb_clone = cpu.clone();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -486,10 +486,10 @@ fn load_permissions(lua: &mut Lua, perms: &PluginPermissions, cpu: &Rc<RefCell<D
     let trimmed_str = perms_str.trim_start_matches("PluginPermissions { ").trim_end_matches(" }");
 
     // Debug
-    println!("Default permissions");
+    println!("\nDefault permissions");
     for line in trimmed_str.split(", ") {
         let (name, value) = line.split_once(": ").unwrap();
-        println!("{}: {}", name.trim(), value.trim());
+        println!("> {}: {}", name.trim(), value.trim());
     }
     println!("---");
 
@@ -505,6 +505,7 @@ fn load_permissions(lua: &mut Lua, perms: &PluginPermissions, cpu: &Rc<RefCell<D
             permissions_map.insert(permission_name, false);
         }
     }
+    println!("---");
 
     // Store HashMap globally
     unsafe {
@@ -514,7 +515,7 @@ fn load_permissions(lua: &mut Lua, perms: &PluginPermissions, cpu: &Rc<RefCell<D
     // Debug
     unsafe {
         if let Some(ref permissions) = PERMISSIONS_HSHMP {
-            println!("\nPermissions saved : {:?}\n", permissions);
+            println!("Permissions saved : {:?}\n---", permissions);
         }
     }
 
@@ -525,7 +526,7 @@ fn load_permissions(lua: &mut Lua, perms: &PluginPermissions, cpu: &Rc<RefCell<D
 
             let all_false = permissions_hshmp.values().all(|&v| !v);
             if all_false {
-                println!("All permissions disabled");
+                println!("All permissions disabled\n");
                 return;
             }
 
@@ -578,6 +579,8 @@ fn load_permissions(lua: &mut Lua, perms: &PluginPermissions, cpu: &Rc<RefCell<D
             }
         }
     }
+    print!("\n");
+
 }
 
 fn pause_cpu(receiver: &Receiver<GBEvent>) {


### PR DESCRIPTION
Display and management of user interactions in the terminal

Use of a `HashMap` to store permissions and their Booleans, so that data can be manipulated more easily

## Examples
User refusal
```
// load plugin
Default permissions
> readbyte: false
> writebyte: true
---
Autorize writebyte ? (y/n, défaut: n): n

Permissions map empty or all permissions disabled.
{"readbyte": false, "writebyte": false}
---
Loaded plugin

// trying to execute plugin
Error during plugin execution: runtime error: type error, expected function, found nil
```

User accept
```
// load plugin
Default permissions
> readbyte: false
> writebyte: true
---
Autorize writebyte ? (y/n, défaut: n): y

Permissions saved: {"writebyte": true, "readbyte": false}
---
Giving writebyte permission

Loaded plugin
```